### PR TITLE
 update to 0.18.8 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - http://staging.continuum.io/prefect/fs/sparse-feedstock/pr3/ab2b7c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - http://staging.continuum.io/prefect/fs/sparse-feedstock/pr3/ab2b7c4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,9 +44,16 @@ test:
 about:
   home: https://github.com/casact/chainladder-python
   summary: Chainladder Package - P&C Loss Reserving package
+  description: |
+    The chainladder package was built to be able to handle all of your actuarial needs in python. It consists of
+    popular actuarial tools, such as triangle data manipulation, link ratios calculation, and IBNR estimates with both
+    deterministic and stochastic models.
   license: MPL-2.0
+  license_family: MPL
   # License file manually packaged. See https://github.com/casact/chainladder-python/pull/102
   license_file: LICENSE
+  doc_url: https://chainladder-python.readthedocs.io
+  dev_url: https://github.com/casact/chainladder-python
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  # skip py39 because of missing sparse
+  skip: True  # [py<39 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/chainladder-{{ version }}.tar.gz
-  sha256: 56eb8bd44d46ca48680122f85d96dba6f33d7a82393a6468786b061f266161dc
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/chainladder-{{ version }}.tar.gz
+    sha256: 56eb8bd44d46ca48680122f85d96dba6f33d7a82393a6468786b061f266161dc
+  - git_url: https://github.com/casact/chainladder-python
+    git_rev: v0.8.18
+    folder: github
 
 build:
   number: 0
@@ -35,13 +38,31 @@ requirements:
     - patsy
 
 test:
+  source_files:
+    - github/chainladder/methods/tests
+    - github/chainladder/core/tests
+    - github/chainladder/adjustments/tests
+    - github/chainladder/utils/tests
+    - github/chainladder/workflow/tests
+    - github/chainladder/tails/tests
+    - github/conftest.py
   imports:
     - chainladder
     - chainladder.core
   commands:
     - pip check
+    - pytest github/chainladder/methods/tests
+    # skipping test to run in jupyter notebook
+    - pytest github/chainladder/core/tests -k "not test_heatmap_render"
+    - pytest github/chainladder/adjustments/tests
+    - pytest github/chainladder/utils/tests
+    - pytest github/chainladder/workflow/tests
+    - pytest github/chainladder/tails/tests
   requires:
     - pip
+    - pytest
+    - lxml
+    - jinja2
 
 about:
   home: https://github.com/casact/chainladder-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "chainladder" %}
-{% set version = "0.8.14" %}
-
+{% set version = "0.8.18" %}
 
 package:
   name: {{ name|lower }}
@@ -13,13 +12,14 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
+    - setuptools
+    - wheel
   run:
     - joblib
     - numpy >=1.12.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
     popular actuarial tools, such as triangle data manipulation, link ratios calculation, and IBNR estimates with both
     deterministic and stochastic models.
   license: MPL-2.0
-  license_family: MPL
+  license_family: MOZILLA
   # License file manually packaged. See https://github.com/casact/chainladder-python/pull/102
   license_file: LICENSE
   doc_url: https://chainladder-python.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ build:
   skip: True  # [py<39 or s390x]
 
 requirements:
+  build:
+    - git  # [not win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/chainladder-{{ version }}.tar.gz
-  sha256: 346c8a71d5d7188b22203da9a49ff35f93e00129bf17b2ea2f45ccc7bd5588ac
+  sha256: 56eb8bd44d46ca48680122f85d96dba6f33d7a82393a6468786b061f266161dc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pandas >=0.23
     - scikit-learn >=0.23
     - scipy
-    - matplotlib
+    - matplotlib-base
     - numba >0.54
     - sparse >=0.9
     - dill

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,14 +21,14 @@ requirements:
     - wheel
   run:
     - joblib
-    - numpy >=1.12.0
-    - pandas >=0.23.0
-    - python >=3.5
-    - scikit-learn >=0.23.0
+    - python
+    - numpy >=1.12
+    - pandas >=0.23
+    - scikit-learn >=0.23
     - scipy
     - matplotlib
-    - numba
-    - sparse
+    - numba >0.54
+    - sparse >=0.9
     - dill
     - patsy
 


### PR DESCRIPTION
chain ladder 0.18.8 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3506]
- [Upstream repository](https://github.com/casact/chainladder-python/tree/v0.8.18)
- [Upstream changelog/diff](https://github.com/casact/chainladder-python/blob/v0.8.18/docs/library/releases.md)
- Relevant dependency PRs:
  - [setuptools-scm](https://github.com/AnacondaRecipes/setuptools_scm-feedstock/pull/7)
  - [sparse](https://github.com/AnacondaRecipes/sparse-feedstock/pull/3)

### Info
- `py39` and `s390x` skipped because of missing sparse support

[PKG-3506]: https://anaconda.atlassian.net/browse/PKG-3506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ